### PR TITLE
Merge for opencv3 as main library

### DIFF
--- a/classification.py
+++ b/classification.py
@@ -43,7 +43,7 @@ class Classifier( object ):
 
 class KNNClassifier( Classifier ):
     def __init__(self, k=1, debug=False):
-        self.knn= cv2.KNearest()
+        self.knn= cv2.ml.KNearest_create()
         self.k=k
         self.debug= debug
 
@@ -53,10 +53,10 @@ class KNNClassifier( Classifier ):
         if CLASS_DATATYPE!=numpy.float32:
             classes= numpy.asarray( classes, dtype=numpy.float32 )
         features, classes= Classifier._filter_unclassified( features, classes )
-        self.knn.train( features, classes )
+        self.knn.train( features,cv2.ml.ROW_SAMPLE, classes )
         
     def classify( self, features):
         if FEATURE_DATATYPE!=numpy.float32:
             features= numpy.asarray( features, dtype=numpy.float32 )
-        retval, result_classes, neigh_resp, dists= self.knn.find_nearest(features, k= 1)
+        retval, result_classes, neigh_resp, dists= self.knn.findNearest(features, k= 1)
         return result_classes

--- a/segmentation.py
+++ b/segmentation.py
@@ -48,7 +48,7 @@ class RawContourSegmenter( RawSegmenter ):
         self.image= image
         image= cv2.cvtColor(image,cv2.COLOR_BGR2GRAY)
         image = cv2.adaptiveThreshold(image, maxValue=255, adaptiveMethod=cv2.ADAPTIVE_THRESH_GAUSSIAN_C, thresholdType=cv2.THRESH_BINARY, blockSize=self.block_size, C=self.c)
-        contours,hierarchy = cv2.findContours(image,cv2.RETR_LIST,cv2.CHAIN_APPROX_SIMPLE)
+        _,contours,hierarchy = cv2.findContours(image,cv2.RETR_LIST,cv2.CHAIN_APPROX_SIMPLE)
         segments= segments_to_numpy( [cv2.boundingRect(c) for c in contours] )
         self.contours, self.hierarchy= contours, hierarchy #store, may be needed for debugging
         return segments


### PR DESCRIPTION
Merge the opencv3 branch with the main branch as `pip install python-opencv` now installs opencv3 and not opencv2 for usability.